### PR TITLE
Introduce `integration` test helper to DRY up integration tests

### DIFF
--- a/__tests__/container-service-integration.test.ts
+++ b/__tests__/container-service-integration.test.ts
@@ -1,7 +1,7 @@
 import {PROXY_IMAGE_NAME, UPDATER_IMAGE_NAME} from '../src/main'
 import {ContainerService} from '../src/container-service'
 import {ImageService} from '../src/image-service'
-import {removeDanglingUpdaterContainers} from './helpers'
+import {removeDanglingUpdaterContainers, integration} from './helpers'
 import Docker from 'dockerode'
 import {Credential, JobDetails} from '../src/api-client'
 import {ProxyBuilder} from '../src/proxy'
@@ -9,12 +9,7 @@ import path from 'path'
 import fs from 'fs'
 import {JobParameters} from '../src/inputs'
 
-describe('ContainerService', () => {
-  // Skip the test when we haven't preloaded the updater image
-  if (process.env.SKIP_INTEGRATION_TESTS) {
-    return
-  }
-
+integration('ContainerService', () => {
   const docker = new Docker()
   const credentials: Credential[] = [
     {

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -54,3 +54,7 @@ export const eventFixturePath = (fixtureName: string): string => {
     `${fixtureName}.json`
   )
 }
+
+export const integration = process.env.SKIP_INTEGRATION_TESTS
+  ? describe.skip
+  : describe

--- a/__tests__/proxy-integration.test.ts
+++ b/__tests__/proxy-integration.test.ts
@@ -3,12 +3,12 @@ import {Credential} from '../src/api-client'
 import {ImageService} from '../src/image-service'
 import {PROXY_IMAGE_NAME} from '../src/main'
 import {ProxyBuilder} from '../src/proxy'
-import {removeDanglingUpdaterContainers} from './helpers'
+import {integration, removeDanglingUpdaterContainers} from './helpers'
 import {spawnSync} from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
-describe('ProxyBuilder', () => {
+integration('ProxyBuilder', () => {
   const docker = new Docker()
   const jobId = 1
   const credentials: Credential[] = [
@@ -23,10 +23,6 @@ describe('ProxyBuilder', () => {
   const builder = new ProxyBuilder(docker, PROXY_IMAGE_NAME)
 
   beforeAll(async () => {
-    // Skip the test when we haven't preloaded the updater image
-    if (process.env.SKIP_INTEGRATION_TESTS) {
-      return
-    }
     await ImageService.pull(PROXY_IMAGE_NAME)
   })
 
@@ -36,11 +32,6 @@ describe('ProxyBuilder', () => {
 
   jest.setTimeout(20000)
   it('should create a proxy container with the right details', async () => {
-    // Skip the test when we haven't preloaded the updater image
-    if (process.env.SKIP_INTEGRATION_TESTS) {
-      return
-    }
-
     const proxy = await builder.run(jobId, credentials)
     await proxy.container.start()
 
@@ -77,10 +68,6 @@ describe('ProxyBuilder', () => {
 
   jest.setTimeout(20000)
   it('copies in a custom root CA if configured', async () => {
-    if (process.env.SKIP_INTEGRATION_TESTS) {
-      return
-    }
-
     // make a tmp dir at the repo root unless it already exists
     const tmpDir = path.join(__dirname, '../tmp')
     if (!fs.existsSync(tmpDir)) {

--- a/__tests__/updater-integration.test.ts
+++ b/__tests__/updater-integration.test.ts
@@ -7,11 +7,15 @@ import {JobParameters} from '../src/inputs'
 import {UPDATER_IMAGE_NAME, PROXY_IMAGE_NAME} from '../src/main'
 import {Updater} from '../src/updater'
 
-import {removeDanglingUpdaterContainers, runFakeDependabotApi} from './helpers'
+import {
+  integration,
+  removeDanglingUpdaterContainers,
+  runFakeDependabotApi
+} from './helpers'
 
 const FAKE_SERVER_PORT = 9000
 
-describe('Updater', () => {
+integration('Updater', () => {
   let server: any
 
   // Used from this action to get job details and credentials
@@ -40,11 +44,6 @@ describe('Updater', () => {
   const apiClient = new ApiClient(client, params)
 
   beforeAll(async () => {
-    // Skip the test when we haven't preloaded the updater image
-    if (process.env.SKIP_INTEGRATION_TESTS) {
-      return
-    }
-
     await ImageService.pull(UPDATER_IMAGE_NAME)
     await ImageService.pull(PROXY_IMAGE_NAME)
 
@@ -54,11 +53,6 @@ describe('Updater', () => {
   })
 
   afterEach(async () => {
-    // Skip the test when we haven't preloaded the updater image
-    if (process.env.SKIP_INTEGRATION_TESTS) {
-      return
-    }
-
     server && server() // teardown server process
     await removeDanglingUpdaterContainers()
     fs.rmdirSync(workingDirectory, {recursive: true})
@@ -66,11 +60,6 @@ describe('Updater', () => {
 
   jest.setTimeout(120000)
   it('should run the updater and create a pull request', async () => {
-    // Skip the test when we haven't preloaded the updater image
-    if (process.env.SKIP_INTEGRATION_TESTS) {
-      return
-    }
-
     const details = await apiClient.getJobDetails()
     const credentials = await apiClient.getCredentials()
 


### PR DESCRIPTION
Previously, we'd manually return from blocks that were only ran in tests
marked as `integration` tests, denoted by files that end in
`*-integration.test.ts`.

This lead to a bunch of duplication, as each
block was still started, and we had to mark several blocks in those
files with a piece of code to return early in the case of integration
tests.

This introduces an `integration` helper, which conditionally skips the
entire suite based on wether or not the `INTEGRATION` env var is set.

This is currently based on `jurre/extract-updater-image-building`, because I didn't set this up correctly there, but figured it deserved it's own PR to make reviewing easier.

Plan is to merge this into that PR and then merge that whole thing into main.