### PR TITLE
V2.2.0 release notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",

--- a/script/bump-version
+++ b/script/bump-version
@@ -27,4 +27,4 @@ git commit -m "${new_version}"
 
 echo "Branch prepared for ${new_version}"
 echo "To prepare a release, run:"
-echo "  gh create ${new_version} --draft --generate-notes"
+echo "  gh release create ${new_version} --draft --generate-notes"


### PR DESCRIPTION
## What's Changed
* Improve annotation of failed jobs by @brrygrdn in https://github.com/github/dependabot-action/pull/113
* Bump dependabot/fetch-metadata from 1.2.1 to 1.3.0 by @dependabot in https://github.com/github/dependabot-action/pull/108
* Bump actions/setup-node from 2.5.1 to 3 by @dependabot in https://github.com/github/dependabot-action/pull/99
* Bump actions/checkout from 2 to 3 by @dependabot in https://github.com/github/dependabot-action/pull/107
* Bump ts-node from 10.2.1 to 10.7.0 by @dependabot in https://github.com/github/dependabot-action/pull/111
* Enable connectivity check by @mctofu in https://github.com/github/dependabot-action/pull/120
* Update CODEOWNERS for org shift by @mctofu in https://github.com/github/dependabot-action/pull/121
* Switch from GHPR to GHCR for images by @brrygrdn in https://github.com/github/dependabot-action/pull/119
* [Dependabot Updates] Remove the docker registry by @brrygrdn in https://github.com/github/dependabot-action/pull/126
* Fix vulnerabilities in minimalist and node-forge by @brrygrdn in https://github.com/github/dependabot-action/pull/127


**Full Changelog**: https://github.com/github/dependabot-action/compare/v2.1.0...v2.2.0-release-notes