### PR TITLE
[Dependabot Updates] Remove the docker registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  ghpr:
-    type: docker-registry
-    url: docker.pkg.github.com
-    username: x
-    password: ${{ secrets.DEPENDABOT_GHPR_TOKEN }}
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
@@ -14,8 +8,6 @@ updates:
     directory: '/docker'
     schedule:
       interval: 'daily'
-    registries:
-      - ghpr
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We are now using `ghcr.io` for our images which permits anonymous access.

Our latest update run verifies this is working as intended without these credentials.