### PR TITLE
Configure ghcr.io as a registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,16 @@ updates:
     directory: '/docker'
     schedule:
       interval: 'daily'
+    registries:
+      - ghcr
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
 
+registries:
+  ghcr:
+    type: docker-registry
+    url: ghcr.io
+    username: x
+    password: ${{ secrets.DEPENDABOT_GHPR_TOKEN }}


### PR DESCRIPTION
It had seemed that we were able to pull from this registry without
authenticating, but I've noticed 401 errors in our update jobs:

```
updater | INFO <job_337020468> Starting update job for github/dependabot-action
  proxy | 2022/04/08 14:16:56 [012] GET https://ghcr.io:443/v2/github/dependabot-update-job-proxy/dependabot-update-job-proxy/tags/list
  proxy | 2022/04/08 14:16:56 [012] 401 https://ghcr.io:443/v2/github/dependabot-update-job-proxy/dependabot-update-job-proxy/tags/list
  proxy | 2022/04/08 14:16:56 [014] GET https://ghcr.io:443/token?service=ghcr.io&scope=repository%3Agithub%2Fdependabot-update-job-proxy%2Fdependabot-update-job-proxy%3Apull
  proxy | 2022/04/08 14:16:56 [014] 200 https://ghcr.io:443/token?service=ghcr.io&scope=repository%3Agithub%2Fdependabot-update-job-proxy%2Fdependabot-update-job-proxy%3Apull
  proxy | 2022/04/08 14:16:56 [016] GET https://ghcr.io:443/v2/github/dependabot-update-job-proxy/dependabot-update-job-proxy/tags/list
  proxy | 2022/04/08 14:16:56 [016] 200 https://ghcr.io:443/v2/github/dependabot-update-job-proxy/dependabot-update-job-proxy/tags/list
  proxy | 2022/04/08 14:16:56 [018] HEAD https://ghcr.io:443/v2/github/dependabot-update-job-proxy/dependabot-update-job-proxy/manifests/v0.0.4
  proxy | 2022/04/08 14:16:56 [018] 401 https://ghcr.io:443/v2/github/dependabot-update-job-proxy/dependabot-update-job-proxy/manifests/v0.0.4
```

I _think_ we need to add this, but I'm interested in hearing other explanations for why this behavior is present 🙂 