### PR TITLE
Bump `dependabot-updater` to pull in updates

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:2b7f7c1905471943879183e67e0ec6b083184824f5ee608852e318a0181dc133"}');
+module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:78200ff10e004dc7c8d06eae2e6962003eeb21a5247e975d1d7fbed0bd765d6d"}');
 
 /***/ }),
 

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:2b7f7c1905471943879183e67e0ec6b083184824f5ee608852e318a0181dc133"}');
+module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:78200ff10e004dc7c8d06eae2e6962003eeb21a5247e975d1d7fbed0bd765d6d"}');
 
 /***/ }),
 

--- a/docker/Dockerfile.updater
+++ b/docker/Dockerfile.updater
@@ -1,1 +1,1 @@
-FROM ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:2b7f7c1905471943879183e67e0ec6b083184824f5ee608852e318a0181dc133
+FROM ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:78200ff10e004dc7c8d06eae2e6962003eeb21a5247e975d1d7fbed0bd765d6d

--- a/docker/containers.json
+++ b/docker/containers.json
@@ -1,4 +1,4 @@
 {
   "proxy": "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c",
-  "updater": "ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:2b7f7c1905471943879183e67e0ec6b083184824f5ee608852e318a0181dc133"
+  "updater": "ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:78200ff10e004dc7c8d06eae2e6962003eeb21a5247e975d1d7fbed0bd765d6d"
 }


### PR DESCRIPTION
Our automation isn't working as intended currently, so this is a manual bump.

Notable change: `dependabot-updater` is now able to respect an ENV var that was introduced in #130.