### PR TITLE
Dependabot updates run monthly and enable automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       interval: "monthly"
   - package-ecosystem: 'npm'
     directory: '/'
+    open-pull-requests-limit: 20
     schedule:
       interval: 'monthly'
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
   - package-ecosystem: 'docker'
     directory: '/docker'
     schedule:
@@ -13,7 +9,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
 
 registries:
   ghcr:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
-      - name: Install NPM dependencies
+      - name: Install npm dependencies
         run: npm ci
 
       - name: Rebuild the dist/ directory

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,19 @@
+name: Dependabot auto-merge
+on: pull_request_target
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch metadata
+        uses: dependabot/fetch-metadata@v1.3.0
+
+      # Enable the automerge using a PAT so the merge commits trigger workflows
+      - name: Auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_AUTOBUILD }}

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -26,7 +26,7 @@ jobs:
   build-dependabot-changes:
     runs-on: ubuntu-latest
     needs: [fetch-dependabot-metadata]
-    # We only need to build the dist/ folder if the PR relates to Docker or a production NPM dependency, otherwise we don't expect changes.
+    # We only need to build the dist/ folder if the PR relates to Docker or a production npm dependency, otherwise we don't expect changes.
     if: needs.fetch-dependabot-metadata.output.package-ecosystem == 'docker' || ( needs.fetch-dependabot-metadata.output.package-ecosystem == 'npm_and_yarn' && needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production' )
     steps:
       # Check out using a PAT so any pushed changes will trigger checkruns
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
-      - name: Install NPM dependencies
+      - name: Install npm dependencies
         run: npm ci
 
       # If we're reacting to a Docker PR, we have on extra step to refresh and check in the container manifest,

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fetch-dependabot-metadata]
     # We only need to build the dist/ folder if the PR relates to Docker or a production npm dependency, otherwise we don't expect changes.
-    if: needs.fetch-dependabot-metadata.output.package-ecosystem == 'docker' || ( needs.fetch-dependabot-metadata.output.package-ecosystem == 'npm_and_yarn' && needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production' )
+    if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'docker' || ( needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn' && needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production' )
     steps:
       # Check out using a PAT so any pushed changes will trigger checkruns
       - uses: actions/checkout@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
-      - name: Install NPM dependencies
+      - name: Install npm dependencies
         run: npm ci
 
       - name: Pre-fetch the pinned images

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
-      - name: Install NPM dependencies
+      - name: Install npm dependencies
         run: npm ci
 
       - name: Check formatting


### PR DESCRIPTION
We want to start using Dependabot updates to establish a maximum release frequency of 1 minor patch per month to keep our dependencies up to date.

In order to make this process as painless as possible, this PR collects a few improvements:
- Fix a malformed condition that was causing the automatic build to **always** skip
- Add a workflow to enable the automerge feature for any Dependabot PRs
  - PRs still require an approval from a required reviewer to actually merge, this just reduces friction