### PR TITLE
Prefer verbose `npm` command as bread crumb

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install npm dependencies
-        run: npm ci
+        run: npm clean-install
 
       - name: Rebuild the dist/ directory
         run: npm run package

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install npm dependencies
-        run: npm ci
+        run: npm clean-install
 
       # If we're reacting to a Docker PR, we have on extra step to refresh and check in the container manifest,
       # this **must** happen before rebuilding dist/ so it uses the new version of the manifest

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install npm dependencies
-        run: npm ci
+        run: npm clean-install
 
       - name: Pre-fetch the pinned images
         run: npm run fetch-images

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install npm dependencies
-        run: npm ci
+        run: npm clean-install
 
       - name: Check formatting
         run: npm run format-check


### PR DESCRIPTION
Likely due to ignorance of the npm ecosystem, I found myself thinking
that `npm ci` was perhaps a directive to execute a **C**ontinuous
**I**ntegration workflow, rather than doing a clean install. Updating
these references in case any future developers share my ignorance.