### PR TITLE
Update logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/7659/174585920-65023f96-fd57-456d-a4a8-464c8c2affcb.svg" alt="Dependabot" width="336">
+  <img src="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg#gh-light-mode-only" alt="Dependabot" width="336">
+    <img src="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg#gh-dark-mode-only" alt="Dependabot" width="336">
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <p align="center">
   <img src="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg#gh-light-mode-only" alt="Dependabot" width="336">
-    <img src="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg#gh-dark-mode-only" alt="Dependabot" width="336">
+  <img src="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg#gh-dark-mode-only" alt="Dependabot" width="336">
 </p>
-
 
 # Updater Action
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center">
-  <img src="https://s3.eu-west-2.amazonaws.com/dependabot-images/logo-with-name-horizontal.svg?v5" alt="Dependabot" width="336">
+  <img src="https://user-images.githubusercontent.com/7659/174585920-65023f96-fd57-456d-a4a8-464c8c2affcb.svg" alt="Dependabot" width="336">
 </p>
+
 
 # Updater Action
 


### PR DESCRIPTION
The logo used in the current README hardcodes the `fill` value for its text to `#24292E`. This causes the text to have a contrast ratio of 1.02:1 against its background color (`#22272E`) when viewed in dark mode.

<img width="841" alt="Logo viewed in dark mode" src="https://user-images.githubusercontent.com/7659/174587129-a10f0c93-d831-4cbc-b105-f500f23f73b0.png">

This PR updates the README to embed two `<img>` elements with `#gh-light-mode-only` / `#gh-dark-mode-only` appended to the `src` URLs. [^1]

```html
<p align="center">
  <img src="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg#gh-light-mode-only" alt="Dependabot" width="336">
  <img src="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg#gh-dark-mode-only" alt="Dependabot" width="336">
</p>
```

The embedded SVGs are uploaded directly to GitHub, whereas the previous was hot-linked from our AWS bucket.

Here are diffs viewed in light and dark themes:

<img width="909" alt="dependabot-logo-light-diff" src="https://user-images.githubusercontent.com/7659/174587903-4103155e-8b32-4fef-96c2-38794c03c781.png">

<img width="908" alt="dependabot-logo-dark-diff" src="https://user-images.githubusercontent.com/7659/174587922-a148f952-9f9b-4806-b6cf-7c9046d719de.png">

You can see this in action by navigating to [the PR branch](https://github.com/github/dependabot-action/tree/mattt/update-logo) and updating your system appearance or [GitHub Theme Preference](https://github.com/settings/appearance).

https://user-images.githubusercontent.com/7659/174587957-e646adc3-b5ca-448f-929f-fafc691b7226.mov

[^1]: https://twitter.com/ashtom/status/1463554157932023808?s=20&t=08el0QKh1cg_9WgexsXjzg

