### PR TITLE
Use versioned Proxy image

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:de86aff88f5bd2a6606aa57f461dce81dc36ec058d737964b115c01aae4bf1e0","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba"}');
+module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:5858e30d0ed4dcbc9f1169ea58c9c7f3d3163a6a4797fc25c6e197aea8a27b1e","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba"}');
 
 /***/ }),
 

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:de86aff88f5bd2a6606aa57f461dce81dc36ec058d737964b115c01aae4bf1e0","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba"}');
+module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:5858e30d0ed4dcbc9f1169ea58c9c7f3d3163a6a4797fc25c6e197aea8a27b1e","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba"}');
 
 /***/ }),
 

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -1,1 +1,1 @@
-FROM ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:de86aff88f5bd2a6606aa57f461dce81dc36ec058d737964b115c01aae4bf1e0
+FROM ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:5858e30d0ed4dcbc9f1169ea58c9c7f3d3163a6a4797fc25c6e197aea8a27b1e

--- a/docker/containers.json
+++ b/docker/containers.json
@@ -1,4 +1,4 @@
 {
-  "proxy": "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:de86aff88f5bd2a6606aa57f461dce81dc36ec058d737964b115c01aae4bf1e0",
+  "proxy": "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:5858e30d0ed4dcbc9f1169ea58c9c7f3d3163a6a4797fc25c6e197aea8a27b1e",
   "updater": "ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba"
 }


### PR DESCRIPTION
## 🖼️ Context

We recently began to version the Proxy image with a scheme that Dependabot can update. This should fix our woes with automation and allow Dependabot to keep these images up-to-date for us.

### 📝 Notes

* The pinned version used here is `v2.0.1`. Once this PR is merged, I expect Dependabot to open a pull request to update the image to the next version: `v2.0.20220622164316`.