### PR TITLE
Fix Rebuild docker/containers.json step typo

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -50,7 +50,7 @@ jobs:
       # If we're reacting to a Docker PR, we have on extra step to refresh and check in the container manifest,
       # this **must** happen before rebuilding dist/ so it uses the new version of the manifest
       - name: Rebuild docker/containers.json
-        if: needs.fetch-dependabot-metadata.output.package-ecosystem == 'docker'
+        if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'docker'
         run: |
           npm run update-container-manifest
           git add docker/containers.json


### PR DESCRIPTION
We were missing an "s" in "outputs", which caused CI to bail early:
<img width="1535" alt="image" src="https://user-images.githubusercontent.com/5278382/175160638-29624cbb-99d6-4670-846d-984627aa9e75.png">
