### PR TITLE
Set updater image to an incrementable version

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:a6031b3134f6ece9fadb298113700584610b41940c6bf9ad8b312e5d44cded5b","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba"}');
+module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:a6031b3134f6ece9fadb298113700584610b41940c6bf9ad8b312e5d44cded5b","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:fc30c3c4598f92943c461d04973b3ae9df3c0a09d757c0c467e2448d87a63d6a"}');
 
 /***/ }),
 

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:a6031b3134f6ece9fadb298113700584610b41940c6bf9ad8b312e5d44cded5b","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba"}');
+module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:a6031b3134f6ece9fadb298113700584610b41940c6bf9ad8b312e5d44cded5b","updater":"ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:fc30c3c4598f92943c461d04973b3ae9df3c0a09d757c0c467e2448d87a63d6a"}');
 
 /***/ }),
 

--- a/docker/Dockerfile.updater
+++ b/docker/Dockerfile.updater
@@ -1,1 +1,1 @@
-FROM ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba
+FROM ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:fc30c3c4598f92943c461d04973b3ae9df3c0a09d757c0c467e2448d87a63d6a

--- a/docker/containers.json
+++ b/docker/containers.json
@@ -1,4 +1,4 @@
 {
   "proxy": "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:a6031b3134f6ece9fadb298113700584610b41940c6bf9ad8b312e5d44cded5b",
-  "updater": "ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:45fba063271b238fbb85479538d9ab8b4e27317674b98dc3e9519036816de3ba"
+  "updater": "ghcr.io/dependabot/dependabot-updater/dependabot-updater@sha256:fc30c3c4598f92943c461d04973b3ae9df3c0a09d757c0c467e2448d87a63d6a"
 }


### PR DESCRIPTION
## 🖼️ Context
There are a couple reasons our automation has been broken around keeping our images up-to-date:
* A typo in the corresponding workflow prevented the update image step
from running
* The images were using non-incrementable versions
  * Dependabot could not reliably assume that one version is greater
  than another

The workflow has been fixed. This PR sets the updater image to a version that Dependabot will be able to update (`v2.0.20220623221933`)