### PR TITLE
Build the `dist/` directory for dev depenencies

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -26,8 +26,8 @@ jobs:
   build-dependabot-changes:
     runs-on: ubuntu-latest
     needs: [fetch-dependabot-metadata]
-    # We only need to build the dist/ folder if the PR relates to Docker or a production npm dependency, otherwise we don't expect changes.
-    if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'docker' || ( needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn' && needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production' )
+    # We only need to build the dist/ folder if the PR relates to Docker or an npm dependency
+    if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'docker' || needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn'
     steps:
       # Check out using a PAT so any pushed changes will trigger checkruns
       - uses: actions/checkout@v3


### PR DESCRIPTION
We've had several builds fail because the `dist/` directory has changes in it after it builds. I don't know the history of excluding dev dependencies from this check, but it seems to be wrong.