### PR TITLE
Node 12 actions are deprecated, bump to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,6 @@ name: 'Updater Action'
 description: 'Runs dependabot-updater in Actions'
 author: 'GitHub'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/main/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
.nvmrc is already set to 16 so this might have just been missed.