### PR TITLE
Bump updater to v2.0.20221205081158

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -34,3 +34,5 @@ jobs:
 
       - name: Run integration tests
         run: npm run test-integration
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -37980,7 +37980,7 @@ module.exports = require("zlib");
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:c4d68b711d260099f5cfa06651910a613617d1c2b585361ac7139904e42a1f59","updater":"ghcr.io/dependabot/dependabot-updater@sha256:3eafe21bc6b337493b870eddc01d652401148b49974bd1747c0aa043fae6c905"}');
+module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:c4d68b711d260099f5cfa06651910a613617d1c2b585361ac7139904e42a1f59","updater":"ghcr.io/dependabot/dependabot-updater@sha256:d8d43dc17c1f0d354429e4cbc90204166193efcdcb000df3a8ef64926e9c08a0"}');
 
 /***/ }),
 

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -80111,7 +80111,7 @@ module.exports = axios;
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:c4d68b711d260099f5cfa06651910a613617d1c2b585361ac7139904e42a1f59","updater":"ghcr.io/dependabot/dependabot-updater@sha256:3eafe21bc6b337493b870eddc01d652401148b49974bd1747c0aa043fae6c905"}');
+module.exports = JSON.parse('{"proxy":"ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:c4d68b711d260099f5cfa06651910a613617d1c2b585361ac7139904e42a1f59","updater":"ghcr.io/dependabot/dependabot-updater@sha256:d8d43dc17c1f0d354429e4cbc90204166193efcdcb000df3a8ef64926e9c08a0"}');
 
 /***/ }),
 

--- a/docker/Dockerfile.updater
+++ b/docker/Dockerfile.updater
@@ -1,1 +1,1 @@
-FROM ghcr.io/dependabot/dependabot-updater@sha256:3eafe21bc6b337493b870eddc01d652401148b49974bd1747c0aa043fae6c905
+FROM ghcr.io/dependabot/dependabot-updater@sha256:d8d43dc17c1f0d354429e4cbc90204166193efcdcb000df3a8ef64926e9c08a0

--- a/docker/containers.json
+++ b/docker/containers.json
@@ -1,4 +1,4 @@
 {
   "proxy": "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy@sha256:c4d68b711d260099f5cfa06651910a613617d1c2b585361ac7139904e42a1f59",
-  "updater": "ghcr.io/dependabot/dependabot-updater@sha256:3eafe21bc6b337493b870eddc01d652401148b49974bd1747c0aa043fae6c905"
+  "updater": "ghcr.io/dependabot/dependabot-updater@sha256:d8d43dc17c1f0d354429e4cbc90204166193efcdcb000df3a8ef64926e9c08a0"
 }


### PR DESCRIPTION
This updates the updater to one of the most recent releases, v2.0.20221205081158.

https://github.com/dependabot/dependabot-core/pkgs/container/dependabot-updater/56976628?tag=v2.0.20221205081158