### PR TITLE
run the update as dependabot

### DIFF
--- a/__tests__/container-service.test.ts
+++ b/__tests__/container-service.test.ts
@@ -1,6 +1,6 @@
 import Docker from 'dockerode'
 
-import {ContainerService} from '../src/container-service'
+import {ContainerService, WAITING_MESSAGE} from '../src/container-service'
 import {ImageService} from '../src/image-service'
 
 describe('ContainerService', () => {
@@ -18,7 +18,11 @@ describe('ContainerService', () => {
         Image: 'alpine',
         AttachStdout: true,
         AttachStderr: true,
-        Cmd: ['/bin/sh', '-c', 'echo $VAR'],
+        Cmd: [
+          '/bin/sh',
+          '-c',
+          `echo "${WAITING_MESSAGE}"; sleep 100; echo $VAR`
+        ],
         Env: ['VAR=env-var']
       })
     })
@@ -35,7 +39,11 @@ describe('ContainerService', () => {
         Image: 'alpine',
         AttachStdout: true,
         AttachStderr: true,
-        Cmd: ['/bin/sh', '-c', 'nosuchccommand']
+        Cmd: [
+          '/bin/sh',
+          '-c',
+          `echo "${WAITING_MESSAGE}"; sleep 100; nosuchccommand`
+        ]
       })
     })
 

--- a/__tests__/updater-integration.test.ts
+++ b/__tests__/updater-integration.test.ts
@@ -58,7 +58,7 @@ integration('Updater', () => {
     fs.rmdirSync(workingDirectory, {recursive: true})
   })
 
-  jest.setTimeout(120000)
+  jest.setTimeout(130_000)
   it('should run the updater and create a pull request', async () => {
     const details = await apiClient.getJobDetails()
     const credentials = await apiClient.getCredentials()

--- a/src/container-service.ts
+++ b/src/container-service.ts
@@ -15,7 +15,7 @@ export const ContainerService = {
     input: FileFetcherInput | FileUpdaterInput | ProxyConfig
   ): Promise<void> {
     const tar = pack()
-    tar.entry({name}, JSON.stringify(input))
+    tar.entry({name, mode: 0o777}, JSON.stringify(input))
     tar.finalize()
     await container.putArchive(tar, {path})
   },

--- a/src/container-service.ts
+++ b/src/container-service.ts
@@ -76,6 +76,11 @@ export const ContainerService = {
         AttachStderr: true
       })
       const execStream = await exec.start({})
+      exec.modem.demuxStream(
+        execStream,
+        outStream('updater'),
+        errStream('updater')
+      )
       await new Promise((resolve, reject) => {
         execStream.on('end', resolve)
         execStream.on('error', reject)

--- a/src/updater-builder.ts
+++ b/src/updater-builder.ts
@@ -26,7 +26,7 @@ export class UpdaterBuilder {
   ) {}
 
   async run(containerName: string): Promise<Container> {
-    const cmd = `echo "Press enter to run the update"; sleep 60;\
+    const cmd = `echo "Press enter to run the update"; sleep 60; mkdir -p ${JOB_OUTPUT_PATH};\
        $DEPENDABOT_HOME/dependabot-updater/bin/run fetch_files &&\
        $DEPENDABOT_HOME/dependabot-updater/bin/run update_files`
 

--- a/src/updater-builder.ts
+++ b/src/updater-builder.ts
@@ -34,8 +34,6 @@ export class UpdaterBuilder {
     const container = await this.docker.createContainer({
       Image: this.updaterImage,
       name: containerName,
-      Tty: true,
-      AttachStdin: true,
       AttachStdout: true,
       AttachStderr: true,
       Env: [

--- a/src/updater-builder.ts
+++ b/src/updater-builder.ts
@@ -26,9 +26,7 @@ export class UpdaterBuilder {
   ) {}
 
   async run(containerName: string): Promise<Container> {
-    const cmd = `(echo > /etc/ca-certificates.conf) &&\
-     rm -Rf /usr/share/ca-certificates/ &&\
-      /usr/sbin/update-ca-certificates &&\
+    const cmd = `echo "Press enter to run the update"; sleep 60;\
        $DEPENDABOT_HOME/dependabot-updater/bin/run fetch_files &&\
        $DEPENDABOT_HOME/dependabot-updater/bin/run update_files`
 
@@ -36,6 +34,8 @@ export class UpdaterBuilder {
     const container = await this.docker.createContainer({
       Image: this.updaterImage,
       name: containerName,
+      Tty: true,
+      AttachStdin: true,
       AttachStdout: true,
       AttachStderr: true,
       Env: [
@@ -55,8 +55,7 @@ export class UpdaterBuilder {
         `UPDATER_ONE_CONTAINER=1`,
         `ENABLE_CONNECTIVITY_CHECK=1`
       ],
-      User: 'root',
-      Cmd: ['sh', '-c', cmd],
+      Cmd: ['bash', '-c', cmd],
       HostConfig: {
         Memory: UPDATER_MAX_MEMORY,
         NetworkMode: this.proxy.networkName,

--- a/src/updater-builder.ts
+++ b/src/updater-builder.ts
@@ -34,6 +34,7 @@ export class UpdaterBuilder {
     const container = await this.docker.createContainer({
       Image: this.updaterImage,
       name: containerName,
+      User: 'dependabot',
       AttachStdout: true,
       AttachStderr: true,
       Env: [
@@ -56,8 +57,7 @@ export class UpdaterBuilder {
       Cmd: ['bash', '-c', cmd],
       HostConfig: {
         Memory: UPDATER_MAX_MEMORY,
-        NetworkMode: this.proxy.networkName,
-        Binds: [`${this.outputHostPath}:${JOB_OUTPUT_PATH}:rw`]
+        NetworkMode: this.proxy.networkName
       }
     })
 

--- a/src/updater-builder.ts
+++ b/src/updater-builder.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import Docker, {Container} from 'dockerode'
-import {ContainerService} from './container-service'
+import {ContainerService, WAITING_MESSAGE} from './container-service'
 import {FileFetcherInput, FileUpdaterInput} from './config-types'
 import {JobParameters} from './inputs'
 import {Proxy} from './proxy'
@@ -26,7 +26,7 @@ export class UpdaterBuilder {
   ) {}
 
   async run(containerName: string): Promise<Container> {
-    const cmd = `echo "Press enter to run the update"; sleep 60; mkdir -p ${JOB_OUTPUT_PATH};\
+    const cmd = `echo "${WAITING_MESSAGE}"; sleep 60; mkdir -p ${JOB_OUTPUT_PATH};\
        $DEPENDABOT_HOME/dependabot-updater/bin/run fetch_files &&\
        $DEPENDABOT_HOME/dependabot-updater/bin/run update_files`
 


### PR DESCRIPTION
For added security we want to run the update container as Dependabot.

To achieve this, we must run `update-ca-certificates` separately as root. 

There is more than one way to achieve this. The is the simplest thing I could think of:

1. Run the updater as `dependabot`
2. Run `echo` as a signal that the container is up since docker exec needs the container to be running
3. Follow that up with a `sleep`
4. Start the exec as root and do the `update-ca-certificates`
5. Next run `killall -u sleep` which terminates the sleep that the `dependabot` user was waiting on
6. Proceed to do the update

This is working but I think I lost the stdout/stderr stream from the container somehow. Putting it up as draft to run the CI and see if it gives any hints, this is still a work in progress!