### PR TITLE
v2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Bump eslint from 8.27.0 to 8.31.0 by @dependabot in https://github.com/github/dependabot-action/pull/394
* Bump lint-staged from 13.0.3 to 13.1.0 by @dependabot in https://github.com/github/dependabot-action/pull/365
* Bump eslint-plugin-jest from 27.1.5 to 27.2.0 by @dependabot in https://github.com/github/dependabot-action/pull/385
* Bump eslint-plugin-github from 4.4.1 to 4.6.0 by @dependabot in https://github.com/github/dependabot-action/pull/389
* Bump @typescript-eslint/parser from 5.43.0 to 5.48.0 by @dependabot in https://github.com/github/dependabot-action/pull/397
* Bump prettier from 2.7.1 to 2.8.1 by @dependabot in https://github.com/github/dependabot-action/pull/380
* Bump @types/jest from 29.2.3 to 29.2.5 by @dependabot in https://github.com/github/dependabot-action/pull/386
* Bump json-server from 0.17.0 to 0.17.1 by @dependabot in https://github.com/github/dependabot-action/pull/346
* Bump @types/node-forge from 1.3.0 to 1.3.1 by @dependabot in https://github.com/github/dependabot-action/pull/353
* Bump @types/node from 18.8.2 to 18.11.18 by @dependabot in https://github.com/github/dependabot-action/pull/391
* Bump wait-port from 1.0.1 to 1.0.4 by @dependabot in https://github.com/github/dependabot-action/pull/326
* Bump @vercel/ncc from 0.34.0 to 0.36.0 by @dependabot in https://github.com/github/dependabot-action/pull/392
* use updater image passed in to the action by @jakecoffman in https://github.com/github/dependabot-action/pull/401
* Bump husky from 8.0.2 to 8.0.3 by @dependabot in https://github.com/github/dependabot-action/pull/411
* Bump eslint-plugin-jest from 27.2.0 to 27.2.1 by @dependabot in https://github.com/github/dependabot-action/pull/418
* Bump @typescript-eslint/parser from 5.48.0 to 5.48.2 by @dependabot in https://github.com/github/dependabot-action/pull/412
* Bump prettier from 2.8.1 to 2.8.3 by @dependabot in https://github.com/github/dependabot-action/pull/420
* Bump eslint-config-prettier from 8.5.0 to 8.6.0 by @dependabot in https://github.com/github/dependabot-action/pull/413
* Bump ts-jest from 29.0.3 to 29.0.5 by @dependabot in https://github.com/github/dependabot-action/pull/419
* Bump eslint-import-resolver-typescript from 3.5.2 to 3.5.3 by @dependabot in https://github.com/github/dependabot-action/pull/415
* Bump eslint from 8.31.0 to 8.32.0 by @dependabot in https://github.com/github/dependabot-action/pull/414
* Bump dependabot/dependabot-updater from v2.0.20230104060258 to v2.0.20230125174240 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/431
* Bump dependabot/fetch-metadata from 1.3.5 to 1.3.6 by @dependabot in https://github.com/github/dependabot-action/pull/428
* v2.5.1 by @pavera in https://github.com/github/dependabot-action/pull/434
* Revert "v2.5.1" by @pavera in https://github.com/github/dependabot-action/pull/436


**Full Changelog**: https://github.com/github/dependabot-action/compare/v2.5.0...v2.6.0