### PR TITLE
Change docker updates to monthly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/docker'
     open-pull-requests-limit: 20
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
     registries:
       - ghcr
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
We only need to update when prepping a new release so daily is too frequent. Changing to monthly to be more in line with the other configs but we'll likely manually trigger the update for a release anyway.