### PR TITLE
v2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Allow env setting to skip cleanup tasks by @mctofu in https://github.com/github/dependabot-action/pull/438
* Allow env setting to control connectivity check by @mctofu in https://github.com/github/dependabot-action/pull/439
* pin ecosystem versions by @jakecoffman in https://github.com/github/dependabot-action/pull/447
* Bump jest and @types/jest by @dependabot in https://github.com/github/dependabot-action/pull/454
* Bump eslint from 8.32.0 to 8.33.0 by @dependabot in https://github.com/github/dependabot-action/pull/451
* Bump @typescript-eslint/parser from 5.48.2 to 5.50.0 by @dependabot in https://github.com/github/dependabot-action/pull/452
* Bump @vercel/ncc from 0.36.0 to 0.36.1 by @dependabot in https://github.com/github/dependabot-action/pull/450
* Bump typescript from 4.9.3 to 4.9.5 by @dependabot in https://github.com/github/dependabot-action/pull/448
* Bump @octokit/webhooks-types from 6.3.6 to 6.10.0 by @dependabot in https://github.com/github/dependabot-action/pull/435
* Bump commander from 9.4.1 to 10.0.0 by @dependabot in https://github.com/github/dependabot-action/pull/417
* Bump axios from 1.1.3 to 1.3.0 by @dependabot in https://github.com/github/dependabot-action/pull/449
* Bump tar-stream from 2.2.0 to 3.0.0 by @dependabot in https://github.com/github/dependabot-action/pull/390
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20221206155623 to v2.0.20230130034108 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/446
* Bump node.js from 16.10.0 to 16.19.0 by @mctofu in https://github.com/github/dependabot-action/pull/471
* Bump npm from 8.19.2 to 9.4.0 by @dependabot in https://github.com/github/dependabot-action/pull/445
* Bump dockerode and @types/dockerode by @dependabot in https://github.com/github/dependabot-action/pull/296
* Bump dependabot/dependabot-updater-github-actions from v2.0.20230130173627 to v2.0.20230201230055 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/474
* Bump dependabot/dependabot-updater-gradle from v2.0.20230130173627 to v2.0.20230201230055 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/475
* Bump dependabot/dependabot-updater-terraform from v2.0.20230130173627 to v2.0.20230201230055 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/472
* Bump dependabot/dependabot-updater-bundler from v2.0.20230130173627 to v2.0.20230201230055 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/476
* Bump dependabot/dependabot-updater-npm from v2.0.20230130173627 to v2.0.20230201230055 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/473
* increase limit to accommodate 16 ecosystem images by @jakecoffman in https://github.com/github/dependabot-action/pull/477
* Bump axios from 1.3.0 to 1.3.1 by @dependabot in https://github.com/github/dependabot-action/pull/490
* Bump npm from 9.4.0 to 9.4.1 by @dependabot in https://github.com/github/dependabot-action/pull/482
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230130034108 to v2.0.20230206213225 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/552
* Change docker updates to monthly schedule by @mctofu in https://github.com/github/dependabot-action/pull/589
* Bump jest from 29.4.1 to 29.4.2 by @dependabot in https://github.com/github/dependabot-action/pull/593
* Bump lint-staged from 13.1.0 to 13.1.1 by @dependabot in https://github.com/github/dependabot-action/pull/591
* Bump prettier from 2.8.3 to 2.8.4 by @dependabot in https://github.com/github/dependabot-action/pull/590
* Bump @typescript-eslint/parser from 5.50.0 to 5.51.0 by @dependabot in https://github.com/github/dependabot-action/pull/595
* Bump @types/node from 18.11.18 to 18.13.0 by @dependabot in https://github.com/github/dependabot-action/pull/592
* Bump npm from 9.4.1 to 9.4.2 by @dependabot in https://github.com/github/dependabot-action/pull/597
* Bump axios from 1.3.1 to 1.3.2 by @dependabot in https://github.com/github/dependabot-action/pull/594
* Bump eslint from 8.33.0 to 8.34.0 by @dependabot in https://github.com/github/dependabot-action/pull/598
* Bump dependabot/dependabot-updater-terraform from v2.0.20230201230055 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/588
* Bump dependabot/dependabot-updater-pub from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/577
* Bump dependabot/dependabot-updater-npm from v2.0.20230201230055 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/583
* Bump dependabot/dependabot-updater-github-actions from v2.0.20230201230055 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/582
* Bump dependabot/dependabot-updater-gitsubmodule from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/581
* Bump dependabot/dependabot-updater-docker from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/586
* Bump dependabot/dependabot-updater-cargo from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/579
* Bump dependabot/dependabot-updater-maven from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/573
* Bump dependabot/dependabot-updater-gomod from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/580
* Bump dependabot/dependabot-updater-elm from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/574
* Bump dependabot/dependabot-updater-composer from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/587
* Bump dependabot/dependabot-updater-gradle from v2.0.20230201230055 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/578
* Bump dependabot/dependabot-updater-pip from v2.0.20230130173627 to v2.0.20230210184231 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/585
* Bump eslint-plugin-github from 4.6.0 to 4.6.1 by @dependabot in https://github.com/github/dependabot-action/pull/642
* Bump jest-circus from 29.4.2 to 29.5.0 by @dependabot in https://github.com/github/dependabot-action/pull/659
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230206213225 to v2.0.20230310184612 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/657
* Bump jest from 29.4.2 to 29.5.0 by @dependabot in https://github.com/github/dependabot-action/pull/663
* Bump axios from 1.3.2 to 1.3.4 by @dependabot in https://github.com/github/dependabot-action/pull/631
* Bump eslint from 8.34.0 to 8.35.0 by @dependabot in https://github.com/github/dependabot-action/pull/621
* Bump json-server from 0.17.1 to 0.17.2 by @dependabot in https://github.com/github/dependabot-action/pull/640
* Bump @typescript-eslint/parser from 5.51.0 to 5.54.1 by @dependabot in https://github.com/github/dependabot-action/pull/661
* Bump lint-staged from 13.1.1 to 13.2.0 by @dependabot in https://github.com/github/dependabot-action/pull/662
* Bump @types/node from 18.13.0 to 18.15.0 by @dependabot in https://github.com/github/dependabot-action/pull/664
* Bump npm from 9.4.2 to 9.6.1 by @dependabot in https://github.com/github/dependabot-action/pull/665
* Bump eslint from 8.35.0 to 8.36.0 by @dependabot in https://github.com/github/dependabot-action/pull/687
* Bump dockerode and @types/dockerode by @dependabot in https://github.com/github/dependabot-action/pull/686
* Bump @types/node from 18.15.0 to 18.15.3 by @dependabot in https://github.com/github/dependabot-action/pull/685
* Bump @typescript-eslint/parser from 5.54.1 to 5.55.0 by @dependabot in https://github.com/github/dependabot-action/pull/684
* Bump eslint-config-prettier from 8.6.0 to 8.7.0 by @dependabot in https://github.com/github/dependabot-action/pull/683
* Bump dependabot/dependabot-updater-gomod from v2.0.20230210184231 to v2.0.20230314124736 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/682
* Bump dependabot/dependabot-updater-gradle from v2.0.20230210184231 to v2.0.20230314124736 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/681
* Bump dependabot/dependabot-updater-terraform from v2.0.20230210184231 to v2.0.20230314124736 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/680
* Bump dependabot/dependabot-updater-composer from v2.0.20230210184231 to v2.0.20230314124736 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/679
* Bump dependabot/dependabot-updater-docker from v2.0.20230210184231 to v2.0.20230314124736 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/678
* Bump dependabot/dependabot-updater-github-actions from v2.0.20230210184231 to v2.0.20230314124736 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/677
* Bump dependabot/dependabot-updater-pub from v2.0.20230210184231 to v2.0.20230314124736 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/676
* Bump @types/jest from 29.4.0 to 29.4.1 by @dependabot in https://github.com/github/dependabot-action/pull/688
* Bump dependabot/dependabot-updater-pip from v2.0.20230210184231 to v2.0.20230314223122 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/694
* Bump dependabot/dependabot-updater-gitsubmodule from v2.0.20230210184231 to v2.0.20230314223122 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/689
* Bump dependabot/dependabot-updater-nuget from v2.0.20230130173627 to v2.0.20230314223122 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/695
* Bump dependabot/dependabot-updater-bundler from v2.0.20230201230055 to v2.0.20230314223122 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/696
* Bump dependabot/dependabot-updater-maven from v2.0.20230210184231 to v2.0.20230314223122 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/697
* Bump dependabot/dependabot-updater-npm from v2.0.20230210184231 to v2.0.20230314231206 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/701
* Bump dependabot/dependabot-updater-elm from v2.0.20230210184231 to v2.0.20230314231206 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/699
* Bump dependabot/dependabot-updater-mix from v2.0.20230130173627 to v2.0.20230314232159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/704
* Bump dependabot/dependabot-updater-cargo from v2.0.20230210184231 to v2.0.20230314233929 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/705
* Bump dependabot/dependabot-updater-mix from v2.0.20230314232159 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/723
* Bump dependabot/dependabot-updater-docker from v2.0.20230314124736 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/722
* Bump dependabot/dependabot-updater-elm from v2.0.20230314231206 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/721
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230310184612 to v2.0.20230314231139 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/717
* Bump dependabot/dependabot-updater-pip from v2.0.20230314223122 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/718
* Bump dependabot/dependabot-updater-gitsubmodule from v2.0.20230314223122 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/719
* Bump dependabot/dependabot-updater-bundler from v2.0.20230314223122 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/720
* Bump dependabot/dependabot-updater-gomod from v2.0.20230314124736 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/714
* Bump dependabot/dependabot-updater-github-actions from v2.0.20230314124736 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/713
* Bump dependabot/dependabot-updater-terraform from v2.0.20230314124736 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/715
* Bump dependabot/dependabot-updater-nuget from v2.0.20230314223122 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/712
* Bump dependabot/dependabot-updater-maven from v2.0.20230314223122 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/716
* Bump dependabot/dependabot-updater-npm from v2.0.20230314231206 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/710
* Bump dependabot/dependabot-updater-gradle from v2.0.20230314124736 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/711
* Bump dependabot/dependabot-updater-pub from v2.0.20230314124736 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/708
* Bump dependabot/dependabot-updater-composer from v2.0.20230314124736 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/709
* Bump dependabot/dependabot-updater-cargo from v2.0.20230314233929 to v2.0.20230315172159 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/707
* Bump dependabot/dependabot-updater-gitsubmodule from v2.0.20230315172159 to v2.0.20230316212504 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/740
* Bump dependabot/dependabot-updater-maven from v2.0.20230315172159 to v2.0.20230317022332 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/756
* Bump dependabot/dependabot-updater-elm from v2.0.20230315172159 to v2.0.20230317123045 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/770
* Bump dependabot/dependabot-updater-npm from v2.0.20230315172159 to v2.0.20230317123045 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/766
* Bump dependabot/dependabot-updater-pip from v2.0.20230315172159 to v2.0.20230317123045 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/757
* Bump dependabot/dependabot-updater-gradle from v2.0.20230315172159 to v2.0.20230317123045 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/765
* Bump dependabot/dependabot-updater-gomod from v2.0.20230315172159 to v2.0.20230317123045 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/761
* Bump dependabot/dependabot-updater-nuget from v2.0.20230315172159 to v2.0.20230317123045 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/758
* Bump dependabot/dependabot-updater-composer from v2.0.20230315172159 to v2.0.20230317123045 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/767
* Bump dependabot/dependabot-updater-bundler from v2.0.20230315172159 to v2.0.20230317123045 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/762
* Bump dependabot/dependabot-updater-terraform from v2.0.20230315172159 to v2.0.20230317130517 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/779
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230314231139 to v2.0.20230317114832 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/754
* Bump dependabot/dependabot-updater-cargo from v2.0.20230315172159 to v2.0.20230317130517 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/775
* Bump dependabot/dependabot-updater-gitsubmodule from v2.0.20230316212504 to v2.0.20230317130517 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/780
* Bump dependabot/dependabot-updater-docker from v2.0.20230315172159 to v2.0.20230317130517 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/774
* Bump dependabot/dependabot-updater-pub from v2.0.20230315172159 to v2.0.20230317130517 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/777
* Bump dependabot/dependabot-updater-github-actions from v2.0.20230315172159 to v2.0.20230317130517 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/776
* Bump dependabot/dependabot-updater-bundler from v2.0.20230317123045 to v2.0.20230317134336 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/782
* Bump dependabot/dependabot-updater-maven from v2.0.20230317022332 to v2.0.20230317134336 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/783
* Bump dependabot/dependabot-updater-mix from v2.0.20230315172159 to v2.0.20230317134336 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/784


**Full Changelog**: https://github.com/github/dependabot-action/compare/v2...v2.7.0