### PR TITLE
Pin `fetch-metadata` by SHA

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Fetch metadata
-        uses: dependabot/fetch-metadata@v1.4.0
+        uses: dependabot/fetch-metadata@efb5c8deb113433243b6b08de1aa879d5aa01cf7 # v1.4.0
 
       # Enable the automerge using a PAT so the merge commits trigger workflows
       - name: Auto-merge

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Fetch dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.4.0
+        uses: dependabot/fetch-metadata@efb5c8deb113433243b6b08de1aa879d5aa01cf7 # v1.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
   build-dependabot-changes:


### PR DESCRIPTION
This is mostly cosmetic, since we control the action so aren't worried about something nefarious happening. But it's also good practice, and makes our security bot reviewer happy.