### PR TITLE
Group :dependabot: PR's for `eslint`-related deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,11 @@ updates:
     labels:
       - dependencies
       - javascript
-      - Fanout      
+      - Fanout
+    groups:
+      eslint-dependencies:
+        patterns:
+          - "*eslint*"
 
 registries:
   ghcr:


### PR DESCRIPTION
There are multiple deps that are `eslint`-related, and since they're all related to a linter, it's very safe to merge them as a single group.