### PR TITLE
Add a group for all dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,9 +33,26 @@ updates:
       - javascript
       - Fanout
     groups:
-      eslint-dependencies:
+      dev-dependencies:
         patterns:
           - "*eslint*"
+          - "@types/*"
+          - "@typescript-eslint/parser"
+          - "@vercel/ncc"
+          - "eslint"
+          - "eslint-*"
+          - "husky"
+          - "jest"
+          - "jest-circus"
+          - "js-yaml"
+          - "json-server"
+          - "lint-staged"
+          - "node-forge"
+          - "prettier"
+          - "ts-jest"
+          - "ts-node"
+          - "typescript"
+          - "wait-port"
 
 registries:
   ghcr:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,6 @@ updates:
     groups:
       dev-dependencies:
         patterns:
-          - "*eslint*"
           - "@types/*"
           - "@typescript-eslint/parser"
           - "@vercel/ncc"


### PR DESCRIPTION
I've included all of the `devDependencies` from `package.json` here. Are there any that would be better to handle as individual PRs?