### PR TITLE
v2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Bump typescript from 4.9.5 to 5.0.3 by @dependabot in https://github.com/github/dependabot-action/pull/821
* Bump prettier from 2.8.4 to 2.8.7 by @dependabot in https://github.com/github/dependabot-action/pull/827
* Bump @typescript-eslint/parser from 5.55.0 to 5.59.0 by @dependabot in https://github.com/github/dependabot-action/pull/847
* Bump eslint-import-resolver-typescript from 3.5.3 to 3.5.5 by @dependabot in https://github.com/github/dependabot-action/pull/846
* Bump @octokit/webhooks-types from 6.10.0 to 6.11.0 by @dependabot in https://github.com/github/dependabot-action/pull/866
* Bump dependabot/fetch-metadata from 1.3.6 to 1.4.0 by @dependabot in https://github.com/github/dependabot-action/pull/851
* Bump yaml from 2.2.1 to 2.2.2 by @dependabot in https://github.com/github/dependabot-action/pull/849
* Add test for CredentialFetchingError by @mctofu in https://github.com/github/dependabot-action/pull/899
* Improve handling of api errors when fetching job details by @mctofu in https://github.com/github/dependabot-action/pull/898
* Configure retries for 5xx API responses and network errors by @mctofu in https://github.com/github/dependabot-action/pull/900
* Adopt experimental group updates for docker images by @brrygrdn in https://github.com/github/dependabot-action/pull/920
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230317114832 to v2.0.20230504224008 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/911
* Add Fanout label to Dependabot PRs by @mctofu in https://github.com/github/dependabot-action/pull/941
* Use the full email for the GitHub Actions bot by @jeffwidman in https://github.com/github/dependabot-action/pull/947
* Pin `fetch-metadata` by SHA by @jeffwidman in https://github.com/github/dependabot-action/pull/946
* Group :dependabot: PR's for `eslint`-related deps by @jeffwidman in https://github.com/github/dependabot-action/pull/954
* Bump dependabot/fetch-metadata from 1.4.0 to 1.5.1 by @dependabot in https://github.com/github/dependabot-action/pull/955
* Bump the eslint-dependencies group with 4 updates by @dependabot in https://github.com/github/dependabot-action/pull/956
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230504224008 to v2.0.20230602210519 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/968
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230602210519 to v2.0.20230608000452 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/969
* Bump axios from 1.3.4 to 1.4.0 by @dependabot in https://github.com/github/dependabot-action/pull/854
* Bump axios-retry from 3.4.0 to 3.5.0 by @dependabot in https://github.com/github/dependabot-action/pull/959
* Bump commander from 10.0.0 to 10.0.1 by @dependabot in https://github.com/github/dependabot-action/pull/855
* Bump @octokit/webhooks-types from 6.11.0 to 7.0.3 by @dependabot in https://github.com/github/dependabot-action/pull/971
* Bump npm from 9.6.1 to 9.7.1 by @dependabot in https://github.com/github/dependabot-action/pull/974
* Add a group for all dev dependencies by @mctofu in https://github.com/github/dependabot-action/pull/975
* Bump the dev-dependencies group with 12 updates by @dependabot in https://github.com/github/dependabot-action/pull/977
* Bump the dependabot-core-images group in /docker with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/976
* Bump the dependabot-core-images group in /docker with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/978

## New Contributors
* @jeffwidman made their first contribution in https://github.com/github/dependabot-action/pull/947

**Full Changelog**: https://github.com/github/dependabot-action/compare/v2...v2.8.0