### PR TITLE
Only group patch and minor dev-dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,25 +40,10 @@ updates:
       - Fanout
     groups:
       dev-dependencies:
-        patterns:
-          - "@types/*"
-          - "@typescript-eslint/parser"
-          - "@vercel/ncc"
-          - "eslint"
-          - "eslint-*"
-          - "husky"
-          - "jest"
-          - "jest-circus"
-          - "js-yaml"
-          - "json-server"
-          - "lint-staged"
-          - "node-forge"
-          - "prettier"
-          - "ts-jest"
-          - "ts-node"
-          - "typescript"
-          - "wait-port"
-
+        dependency-type: "development"
+        update-types:
+        - "patch"
+        - "minor"
 registries:
   ghcr:
     type: docker-registry


### PR DESCRIPTION
Major updates are more likely to break CI, so let's open separate PRs for those. Also use the new-fangled `dependency-type` config options instead of listing all the deps out.