### PR TITLE
v2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Bump the dev-dependencies group with 7 updates by @dependabot in https://github.com/github/dependabot-action/pull/980
* Bump commander from 10.0.1 to 11.0.0 by @dependabot in https://github.com/github/dependabot-action/pull/981
* Bump @octokit/webhooks-types from 7.0.3 to 7.1.0 by @dependabot in https://github.com/github/dependabot-action/pull/982
* Bump axios-retry from 3.5.0 to 3.5.1 by @dependabot in https://github.com/github/dependabot-action/pull/983
* Bump dependabot/fetch-metadata from 1.5.1 to 1.6.0 by @dependabot in https://github.com/github/dependabot-action/pull/986
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230608000452 to v2.0.20230629024521 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/988
* Bump tar-stream from 3.0.0 to 3.1.6 by @dependabot in https://github.com/github/dependabot-action/pull/989
* Bump npm from 9.7.1 to 9.8.0 by @dependabot in https://github.com/github/dependabot-action/pull/990
* Bump the dependabot-core-images group in /docker with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/991
* Update dependabot.yml by @bdragon in https://github.com/github/dependabot-action/pull/992
* Shift dependabot version updates to Sunday by @mctofu in https://github.com/github/dependabot-action/pull/996
* Bump the dev-dependencies group with 9 updates by @dependabot in https://github.com/github/dependabot-action/pull/993
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230629024521 to v2.0.20230719163840 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/998
* Bump npm from 9.8.0 to 9.8.1 by @dependabot in https://github.com/github/dependabot-action/pull/1002
* Bump the dependabot-core-images group in /docker with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/1004
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230719163840 to v2.0.20230727200608 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1008
* Bump the dependabot-core-images group in /docker with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/1009
* Fix re-run detection and improve messaging by @mctofu in https://github.com/github/dependabot-action/pull/1010
* Only group patch and minor dev-dependencies by @jurre in https://github.com/github/dependabot-action/pull/1016
* Bump the dev-dependencies group with 6 updates by @dependabot in https://github.com/github/dependabot-action/pull/1022
* Bump ci from 2.2.0 to 2.3.0 by @dependabot in https://github.com/github/dependabot-action/pull/1019
* Bump axios-retry from 3.5.1 to 3.6.0 by @dependabot in https://github.com/github/dependabot-action/pull/1005
* remove unused dependency (ci) by @jakecoffman in https://github.com/github/dependabot-action/pull/1024
* remove unused dependency (npm) by @jakecoffman in https://github.com/github/dependabot-action/pull/1025
* Bump @octokit/webhooks-types from 7.1.0 to 7.2.0 by @dependabot in https://github.com/github/dependabot-action/pull/1018
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230727200608 to v2.0.20230809182251 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1017
* remove unused dependency (js-yaml) by @jakecoffman in https://github.com/github/dependabot-action/pull/1026
* Bump lint-staged from 13.2.3 to 14.0.0 by @dependabot in https://github.com/github/dependabot-action/pull/1030
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230809182251 to v2.0.20230825174152 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1034
* Bump eslint-config-prettier from 8.8.0 to 9.0.0 by @dependabot in https://github.com/github/dependabot-action/pull/1029
* Bump the dependabot-core-images group in /docker with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/1040
* Bump the dev-dependencies group with 8 updates by @dependabot in https://github.com/github/dependabot-action/pull/1042
* Bump axios-retry from 3.6.0 to 3.7.0 by @dependabot in https://github.com/github/dependabot-action/pull/1041
* Bump axios from 1.4.0 to 1.5.0 by @dependabot in https://github.com/github/dependabot-action/pull/1038
* Bump actions/checkout from 3 to 4 by @dependabot in https://github.com/github/dependabot-action/pull/1045
* Bump @actions/core from 1.10.0 to 1.10.1 by @dependabot in https://github.com/github/dependabot-action/pull/1047
* Bump @octokit/webhooks-types from 7.2.0 to 7.3.1 by @dependabot in https://github.com/github/dependabot-action/pull/1046
* Bump the dependabot-core-images group in /docker with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/1052
* Upgrade from node16 to node20 by @Nishnha in https://github.com/github/dependabot-action/pull/1050
* Revert "Upgrade from node16 to node20" by @Nishnha in https://github.com/github/dependabot-action/pull/1053
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230825174152 to v2.0.20230921204854 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1058

## New Contributors
* @bdragon made their first contribution in https://github.com/github/dependabot-action/pull/992

**Full Changelog**: https://github.com/github/dependabot-action/compare/v2...v2.9.0