### PR TITLE
v2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Update `(write access required)` message by @Pantelis-Santorinios in https://github.com/github/dependabot-action/pull/1062
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20230921204854 to v2.0.20231006011356 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1067
* Bump the dependabot-core-images group in /docker with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/1068

## New Contributors
* @Pantelis-Santorinios made their first contribution in https://github.com/github/dependabot-action/pull/1062

**Full Changelog**: https://github.com/github/dependabot-action/compare/v2...v2.10.0