### PR TITLE
v2.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20240405134646 to v2.0.20240426163112 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1212
* Bump the dependabot-core-images group across 1 directory with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/1214
* Bump node from 16 to 20 by @mctofu in https://github.com/github/dependabot-action/pull/1104
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20240426163112 to v2.0.20240531140617 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1229
* Bump the dependabot-core-images group across 1 directory with 16 updates by @dependabot in https://github.com/github/dependabot-action/pull/1231


**Full Changelog**: https://github.com/github/dependabot-action/compare/v2.14.0...v2.15.0