### PR TITLE
Start using `node-version-file` param

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -16,14 +16,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Read .nvmrc
-        id: nvm
-        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
+          node-version-file: .nvmrc
 
       - name: Install npm dependencies
         run: npm clean-install

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -35,14 +35,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.DEPENDABOT_AUTOBUILD }}
 
-      - name: Read .nvmrc
-        id: nvm
-        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
+          node-version-file: .nvmrc
 
       - name: Install npm dependencies
         run: npm clean-install

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,14 +17,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Read .nvmrc
-        id: nvm
-        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
+          node-version-file: .nvmrc
 
       - name: Install npm dependencies
         run: npm clean-install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Read .nvmrc
-        id: nvm
-        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
+          node-version-file: .nvmrc
 
       - name: Install npm dependencies
         run: npm clean-install


### PR DESCRIPTION
We don't need to manually read it because `actions/setup-node` supports directly reading the `.nvmrc` file.

We already did this change over a year ago in `fetch-metadata` here:
* https://github.com/dependabot/fetch-metadata/pull/370