### PR TITLE
Silence audit and funding messages from `npm`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+audit=false
+fund=false


### PR DESCRIPTION
While reviewing some logs, I noticed the following:
```shell
added 1 package, changed 30 packages, and audited 382 packages in 6s

58 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

While I'm not against security, nor supporting OSS maintainers (I co-maintain 10+ projects myself!), I am against noisy logs that add no value.

So let's silence these:

1. When they appear in CI, they add no value.
1. We've got our own security tools for vulnerable deps, which we rely on instead of `npm audit` results.
1. When I'm skimming logs looking for debug information, these just get in my way.
1. There may be a speed boost if the audit/fix metadata requires an additional API call,  and silencing actually skips that rather than merely silencing it.

There's multiple ways to silence these: https://benjamincrozat.com/disable-packages-are-looking-for-funding

Originally I tackled this by adding `--no-audit --no-fund` flags, but there's a lot of different entrypoints and workflows that call `npm ci` or `npm install`. Even if I do manage to get them all, there's always a risk someone will come along later and add another entrypoint. So that's why I went the `.npmrc` route.

After this change, the logs are much better:
```shell
added 1 package, changed 30 packages, and audited 382 packages in 6s
```