### PR TITLE
v2.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.20.0",
+      "version": "2.21.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Bump the dependabot-core-images group across 1 directory with 18 updates by @dependabot in https://github.com/github/dependabot-action/pull/1335
* Bump the dependabot-core-images group in /docker with 17 updates by @dependabot in https://github.com/github/dependabot-action/pull/1336
* Add `dotnet-sdk` ecosystem support by @JamieMagee in https://github.com/github/dependabot-action/pull/1338
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20241004183849 to v2.0.20241126032308 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1343
* Bump the prod-dependencies group across 1 directory with 3 updates by @dependabot in https://github.com/github/dependabot-action/pull/1317
* Bump the dependabot-core-images group in /docker with 19 updates by @dependabot in https://github.com/github/dependabot-action/pull/1347
* Bump eslint-plugin-jest from 27.9.0 to 28.9.0 by @dependabot in https://github.com/github/dependabot-action/pull/1346
* Bump the npm_and_yarn group across 1 directory with 2 updates by @dependabot in https://github.com/github/dependabot-action/pull/1348
* Bump the dev-dependencies group across 1 directory with 10 updates by @dependabot in https://github.com/github/dependabot-action/pull/1345

## New Contributors
* @JamieMagee made their first contribution in https://github.com/github/dependabot-action/pull/1338

**Full Changelog**: https://github.com/github/dependabot-action/compare/v2...v2.21.0