### PR TITLE
Set the test timeout to 15 seconds

### DIFF
--- a/__tests__/updater-builder-integration.test.ts
+++ b/__tests__/updater-builder-integration.test.ts
@@ -91,5 +91,5 @@ integration('UpdaterBuilder', () => {
 
     await proxy.shutdown()
     await container.remove()
-  }, 30000)
+  }, 15000)
 })


### PR DESCRIPTION
The test default timeout is 5 seconds. The `beforeAll` step has a separate timeout.

This test was timing out originally at 9 seconds, so that indicates the `beforeAll` step takes around 4 seconds.

Experimenting showed the test completes around 12-15 seconds, of which 4 seconds are the `beforeAll` step, so the test itself takes 8-11 seconds. But I forgot we have auto-merge enabled, so my experimental timeout of 30 seconds got merged when I wasn't planning to...

A 15 second timeout should be all we need.