### PR TITLE
v2.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Bump the dev-dependencies group with 2 updates by @dependabot in https://github.com/github/dependabot-action/pull/1351
* Bump the dependabot-core-images group across 1 directory with 19 updates by @dependabot in https://github.com/github/dependabot-action/pull/1355
* Bump eslint-plugin-github from 4.10.2 to 5.1.4 by @dependabot in https://github.com/github/dependabot-action/pull/1352
* Bump @types/node from 20.12.7 to 22.10.1 by @dependabot in https://github.com/github/dependabot-action/pull/1353
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20241126032308 to v2.0.20241211065819 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1357
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20241211065819 to v2.0.20241211194452 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1359
* Set the test timeout to 15 seconds by @jeffwidman in https://github.com/github/dependabot-action/pull/1363
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20241211194452 to v2.0.20241213020825 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1364
* Bump the dependabot-core-images group in /docker with 19 updates by @dependabot in https://github.com/github/dependabot-action/pull/1366
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20241213020825 to v2.0.20250106164350 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1376


**Full Changelog**: https://github.com/github/dependabot-action/compare/v2...v2.22.0