### PR TITLE
Add javascript Dockerfile

### DIFF
--- a/docker/Dockerfile.javascript
+++ b/docker/Dockerfile.javascript
@@ -1,0 +1,1 @@
+FROM ghcr.io/dependabot/dependabot-updater-javascript:v2.0.20250128173411@sha256:756a396465353e0d347005d98abc11aa8f30ab224c9d81e5ee15bc7c0ba7c542


### PR DESCRIPTION
As part of the addition of the new ecosystem for `bun` we require a `javascript` docker image.

Part of https://github.com/github/dependabot-updates/issues/7990