### PR TITLE
v2.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.23.0",
+      "version": "2.24.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Add instructions for manually upgrading on GHES by @jeffwidman in https://github.com/github/dependabot-action/pull/1402
* Bump the dependabot-core-images group across 1 directory with 19 updates by @dependabot in https://github.com/github/dependabot-action/pull/1404
* Revert "Bump the dependabot-core-images group across 1 directory with 19 updates" by @rickreyhsig in https://github.com/github/dependabot-action/pull/1405
* Add Backoff and Retry Mechanism for Image Pull by @honeyankit in https://github.com/github/dependabot-action/pull/1409
* Adding Docker Compose ecosystem images by @robaiken in https://github.com/github/dependabot-action/pull/1410
* Add the bun ecosystem by @markhallen in https://github.com/github/dependabot-action/pull/1411
* Add the uv ecosystem by @markhallen in https://github.com/github/dependabot-action/pull/1414
* Bump undici from 5.28.4 to 5.28.5 in the npm_and_yarn group by @dependabot in https://github.com/github/dependabot-action/pull/1397
* Bump the npm_and_yarn group with 4 updates by @dependabot in https://github.com/github/dependabot-action/pull/1418
* Bump the dependabot-core-images group across 1 directory with 22 updates by @dependabot in https://github.com/github/dependabot-action/pull/1420
* Bump the dev-dependencies group across 1 directory with 11 updates by @dependabot in https://github.com/github/dependabot-action/pull/1419
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20250128153834 to v2.0.20250228224058 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1415
* Bump dependabot/fetch-metadata from 2.2.0 to 2.3.0 by @dependabot in https://github.com/github/dependabot-action/pull/1388
* Bump dockerode from 4.0.2 to 4.0.4 in the prod-dependencies group across 1 directory by @dependabot in https://github.com/github/dependabot-action/pull/1384
* Bump eslint-config-prettier from 9.1.0 to 10.1.1 by @dependabot in https://github.com/github/dependabot-action/pull/1423
* Bump github/dependabot-update-job-proxy/dependabot-update-job-proxy from v2.0.20250228224058 to v2.0.20250310190033 in /docker by @dependabot in https://github.com/github/dependabot-action/pull/1425
* Bump the dependabot-core-images group in /docker with 22 updates by @dependabot in https://github.com/github/dependabot-action/pull/1421

## New Contributors
* @rickreyhsig made their first contribution in https://github.com/github/dependabot-action/pull/1405
* @robaiken made their first contribution in https://github.com/github/dependabot-action/pull/1410
* @markhallen made their first contribution in https://github.com/github/dependabot-action/pull/1411

**Full Changelog**: https://github.com/github/dependabot-action/compare/v2...v2.24.0