### PR TITLE
Remove unused `fetch-metadata` step

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,12 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
-      - name: Fetch metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
-
-      # Enable the automerge using a PAT so the merge commits trigger workflows
       - name: Auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --merge "${{ github.event.pull_request.html_url }}"
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          # Enable the automerge using a PAT so the merge commits trigger workflows
           GITHUB_TOKEN: ${{ secrets.DEPENDABOT_AUTOBUILD }}


### PR DESCRIPTION
The `fetch-metadata` step isn't used, so removed it.

I checked `git blame` and this appears to have been unused from the start, not sure how it crept in here.

This is in-preparation to a follow-on PR that will swap away from using a PAT... I split it out as there's a few ways we may eliminate the PAT, so wanted to be sure to land this regardless.