### PR TITLE
Enable caching of `npm install`/`npm ci` for `setup-node` action

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -14,13 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: 'npm'
 
-      - name: Install npm dependencies
-        run: npm clean-install
+      - run: npm clean-install
 
       - name: Rebuild the dist/ directory
         run: npm run package

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -32,16 +32,14 @@ jobs:
       # Check out using a PAT so any pushed changes will trigger checkruns
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.DEPENDABOT_AUTOBUILD }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: 'npm'
 
-      - name: Install npm dependencies
-        run: npm clean-install
+      - run: npm clean-install
 
       # If we're reacting to a Docker PR, we have on extra step to refresh and check in the container manifest,
       # this **must** happen before rebuilding dist/ so it uses the new version of the manifest

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,18 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: 'npm'
 
-      - name: Install npm dependencies
-        run: npm clean-install
+      - run: npm clean-install
 
       - name: Pre-fetch the pinned images
         run: npm run fetch-images -- bundler
 
-      - name: Run integration tests
-        run: npm run test-integration
+      - run: npm run test-integration
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: 'npm'
 
-      - name: Install npm dependencies
-        run: npm clean-install
+      - run: npm clean-install
 
-      - name: Check formatting
-        run: npm run format-check
+      - run: npm run format-check
 
-      - name: Run linter
-        run: npm run lint-check
+      - run: npm run lint-check
 
-      - name: Run tests
-        run: npm run test
+      - run: npm run test


### PR DESCRIPTION
The `setup-node` action now supports caching the results of `npm install`/`npm ci`: 
https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/