### PR TITLE
add a manually run build workflow

### DIFF
--- a/.github/workflows/dependabot-build-dispatched.yml
+++ b/.github/workflows/dependabot-build-dispatched.yml
@@ -1,0 +1,48 @@
+name: Compile dependabot updates (dispatched)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to build'
+        required: true
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  build-dependabot-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Use the ref provided by the workflow_dispatch input
+          ref: ${{ github.event.inputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - run: npm clean-install
+
+      # If we're reacting to a Docker PR, we have on extra step to refresh and check in the container manifest,
+      # this **must** happen before rebuilding dist/ so it uses the new version of the manifest
+      - name: Rebuild docker/containers.json
+        if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'docker'
+        run: |
+          npm run update-container-manifest
+          git add docker/containers.json
+
+      - name: Rebuild the dist/ directory
+        run: npm run package
+
+      - name: Check in any change to dist/
+        run: |
+          git add dist/
+          # Specifying the full email allows the avatar to show up: https://github.com/orgs/community/discussions/26560
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "[dependabot skip] Update dist/ with build changes" || exit 0
+          git push


### PR DESCRIPTION
This workflow will allow us to run builds on branches without launching a Codespace. 

It's also a temporary fix for the automatic one that we used to use with a PAT but we're switching to an App. That's taking a bit to complete so in the meantime this should work.