### PR TITLE
fix 403s perhaps, registry creds may not be needed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  ghcr:
-    type: docker-registry
-    url: ghcr.io
-    username: x
-    password: ${{ secrets.BASE_CONTAINER_IMAGE_READER_DEPENDABOT }}
 updates:
   - package-ecosystem: "docker"
     directory: "/docker"
@@ -13,8 +7,6 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    registries:
-      - ghcr
     labels:
       - dependencies
       - docker


### PR DESCRIPTION
I'm seeing 403s in the logs and thought we could try without creds again since all the images are public.

Originally the creds were added in #131 and you can see there was confusion there why they were needed. So let's try again without and see if we can simply things.