### PR TITLE
Add path to npm registry definition

### DIFF
--- a/src/updater.ts
+++ b/src/updater.ts
@@ -119,6 +119,9 @@ export class Updater {
     if (!credential.registry && credential.url) {
       try {
         obj.registry = new URL(credential.url).hostname
+        if (credential.type === 'npm_registry') {
+          obj.registry += `/${new URL(credential.url).pathname}`
+        }
       } catch {
         // If the URL is invalid, we skip setting the registry
         // as it will fall back to the default registry for the given type (e.g., npm, Docker, or Composer).


### PR DESCRIPTION
NPM in dependabot-core uses the registry key for certain operations, but expects the host+path to be configured.