### PR TITLE
Avoid duplicate -d flag by making docker URL option long-only

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ cli
     'A URL for Dependabot API is required.'
   )
   .option(
-    '-d, --dependabot-api-docker-url <url>',
+    '--dependabot-api-docker-url <url>',
     'A URL to be used to access the API from Dependabot containers.'
   )
   .parse(process.argv)


### PR DESCRIPTION
## Changes 

Fixes the following error

> 
> Error: Cannot add option '-d, --dependabot-api-docker-url <url>' due to conflicting flag '-d'
> -  already used by option '-d, --dependabot-api-url <url>'
>     at Command._registerOption (C:\Users\Yeikel\WebstormProjects\dependabot-action\node_modules\commander\lib\command.js:612:13)
> 