### PR TITLE
Add Dependabot monitoring of devcontainer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,16 @@ updates:
       - dependencies
       - github_actions
       - Fanout
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    labels:
+      - dependencies
+      - devcontainers
+      - Fanout
   - package-ecosystem: "npm"
     directory: "/"
     open-pull-requests-limit: 20


### PR DESCRIPTION
Adds a `devcontainers` update entry to the Dependabot config so Dev Container dependencies are kept up to date, following the same schedule and labeling conventions as the other ecosystems.