### PR TITLE
Use native flat Prettier config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,24 +4,14 @@ import jest from "eslint-plugin-jest";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import globals from "globals";
 import tsParser from "@typescript-eslint/parser";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
-});
+import eslintConfigPrettier from "eslint-config-prettier/flat";
 
 const githubConfigs = github.getFlatConfigs();
 
 export default defineConfig([
     js.configs.recommended,
-    ...compat.extends("prettier"),
+    eslintConfigPrettier,
     githubConfigs.recommended,
     githubConfigs.typescript,
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "tar-stream": "^3.2.0"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "^3.3.6",
         "@eslint/js": "^10.0.1",
         "@types/dockerode": "^4.0.1",
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "tar-stream": "^3.2.0"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",
     "@types/dockerode": "^4.0.1",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary

- replace `FlatCompat.extends("prettier")` with `eslint-config-prettier/flat`
- remove the compatibility-only path and URL setup
- remove the direct `@eslint/eslintrc` dependency

`eslint-plugin-github` still installs `@eslint/eslintrc` transitively for its own use.

## Stack

- stacked on #1749
- merge #1749 first, then retarget this PR to `main`

## Validation

- compared calculated rules and settings for source and test files
- `npm clean-install`
- `npm run lint-check`
- `npm run format-check`
- `npx tsc --noEmit`
- `git diff --check`