### PR TITLE
Add repository-wide TypeScript typecheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
 
       - run: npm run format-check
 
+      - run: npm run typecheck
+
       - run: npm run lint-check
 
       - run: npm run test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,7 @@ export default defineConfig([
         sourceType: "module",
 
         parserOptions: {
-            project: "./tsconfig.eslint.json",
+            project: "./tsconfig.json",
         },
     },
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint --fix **/*.ts",
     "lint-check": "eslint **/*.ts",
+    "typecheck": "tsc --noEmit",
     "package": "ncc build -o dist/main src/main.ts --source-map --license licenses.txt && ncc build -o dist/cleanup src/cleanup.ts --source-map --license licenses.txt",
     "test": "SKIP_INTEGRATION_TESTS=true jest --detectOpenHandles",
     "test-integration": "jest --detectOpenHandles 'integration'",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": [
-    "__tests__/**/*.ts",
-    "src/**/*.ts"
-  ]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "forceConsistentCasingInFileNames": true, /* Error if requiring a file by a casing different from the casing on disk */
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["__tests__/**/*.ts", "src/**/*.ts"],
   "exclude": ["**/node_modules/**"]
 }


### PR DESCRIPTION
## Summary

- make the root TypeScript project cover both source and test files
- use that project for ESLint and remove the redundant ESLint-only configuration
- add a `typecheck` script using `tsc --noEmit`
- run typechecking in the main test workflow after the fast formatting check

This matches the explicit typecheck used by `dependabot/fetch-metadata`. Neither ncc nor a future esbuild migration provides semantic TypeScript checking.

## TypeScript configuration

The root `tsconfig.json` previously included only `src/**/*.ts`. Because ESLint uses type-aware rules and also lints files under `__tests__/`, `tsconfig.eslint.json` was added to extend the root configuration with both source and test files.

This PR makes the root configuration the canonical repository-wide TypeScript project by including both directories there. TypeScript, ESLint, editors, and CI can therefore use the same project, and the ESLint-specific configuration is no longer needed. Packaging remains scoped by the explicit ncc entry points, so including tests in the TypeScript project does not add them to the production bundles. The same remains true for a future esbuild migration.

## Validation

- `npm run format-check`
- `npm run typecheck`
- `npm run lint-check`
- `GITHUB_ACTOR=github-actions GITHUB_EVENT_NAME=pull_request npm test -- --runInBand`
- `npm run package`