### PR TITLE
Remove unused updater timeout fixture

### DIFF
--- a/__tests__/server/db.json
+++ b/__tests__/server/db.json
@@ -18,7 +18,6 @@
       "existing-pull-requests": [],
       "ignore-conditions": [],
       "lockfile-only": false,
-      "max-updater-run-time": 2700,
       "package-manager": "npm_and_yarn",
       "source": {
         "provider": "github",


### PR DESCRIPTION
Remove the unused `max-updater-run-time` field from the fake job-details response.

The action does not declare or consume this field, so this only updates test data to match the current job contract.

Validated with Node 24.13.0:

- `npm run format-check`
- `npm run lint-check`
- `npm run typecheck`
- `npm test` (134 passed, 17 skipped)
- `npm run package`

Packaging produced no tracked `dist` changes.

Related:
* https://github.com/dependabot/dependabot-core/pull/15864