### PR TITLE
v3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Bump the dependabot-core-images group across 1 directory with 34 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1717
* Bump the dependabot-core-images group in /docker with 34 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1718
* Add scope property to credentials metadata json object by @AbhishekBhaskar in https://github.com/github/dependabot-action/pull/1722
* Bump the dev-dependencies group across 1 directory with 9 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1721
* Bump actions/checkout from 6 to 7 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1720
* Bump actions/create-github-app-token from 3.1.1 to 3.2.0 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1693
* Bump the dev-dependencies group across 1 directory with 6 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1728
* Add Dependabot monitoring of devcontainer by @jeffwidman in https://github.com/github/dependabot-action/pull/1735
* Bump the dev-dependencies group across 1 directory with 5 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1731
* Bump dockerode from 5.0.0 to 5.0.1 in the prod-dependencies group across 1 directory by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1724
* Bump lint-staged from 16.4.0 to 17.0.8 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1727
* Bump eslint from 9.39.2 to 10.7.0 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1733
* Bump @types/node from 25.6.2 to 26.1.2 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1732
* Bump the dev-dependencies group across 1 directory with 8 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1739
* Bump morgan from 1.10.1 to 1.11.0 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1730
* Bump the dev-dependencies group across 1 directory with 5 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1748
* Bump brace-expansion from 1.1.11 to 1.1.18 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1746
* Bump @grpc/grpc-js from 1.12.6 to 1.14.4 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1713
* Bump the dependabot-core-images group across 1 directory with 34 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1734
* Bump actions/setup-node from 6 to 7 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1736
* Bump commander from 14.0.3 to 15.0.0 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1702
* Bump @eslint/js from 9.39.5 to 10.0.1 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1636
* Bump typescript from 5.9.3 to 6.0.3 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1686
* Adopt ESLint 10 recommended rules and ES2024 by @jeffwidman in https://github.com/github/dependabot-action/pull/1749
* Use native flat Prettier config by @jeffwidman in https://github.com/github/dependabot-action/pull/1750
* Bump @types/node from 26.1.2 to 26.2.0 in the dev-dependencies group by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1752
* Add repository-wide TypeScript typecheck by @jeffwidman in https://github.com/github/dependabot-action/pull/1754
* Replace ncc with esbuild by @jeffwidman in https://github.com/github/dependabot-action/pull/1755
* Remove unused updater timeout fixture by @jeffwidman in https://github.com/github/dependabot-action/pull/1756
* Wait for proxy readiness before starting updater by @jurre in https://github.com/github/dependabot-action/pull/1757
* Bump the dependabot-core-images group in /docker with 34 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1758
* Attempt and await all Docker cleanup without failing Dependabot jobs by @jeffwidman in https://github.com/github/dependabot-action/pull/1753
* pass in all configured experiments by @jakecoffman in https://github.com/github/dependabot-action/pull/1761
* Bump undici, @actions/http-client and @actions/github by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1620
* Bump @actions/http-client from 3.0.2 to 4.0.1 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1672
* Bump the dev-dependencies group across 1 directory with 5 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1759
* Bump the dependabot-core-images group across 1 directory with 34 updates by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1760
* Bump @actions/core from 2.0.2 to 3.0.1 by @dependabot[bot] in https://github.com/github/dependabot-action/pull/1671


**Full Changelog**: https://github.com/github/dependabot-action/compare/v3.2.0...v3.3.0