### PR TITLE
Set `PACKAGE_MANAGER` on the proxy container

### DIFF
--- a/__tests__/proxy-integration.test.ts
+++ b/__tests__/proxy-integration.test.ts
@@ -13,6 +13,7 @@ integration('ProxyBuilder', () => {
   const jobId = 1
   const jobToken = 'xxxyyyzzzz'
   const dependabotApiUrl = 'http://localhost:9000'
+  const packageManager = 'npm_and_yarn'
   const credentials: Credential[] = [
     {
       type: 'git_source',
@@ -38,7 +39,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
     await proxy.waitUntilReady()
@@ -96,7 +98,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
 
@@ -128,7 +131,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
 
@@ -154,7 +158,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
 
@@ -173,7 +178,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
 
@@ -193,7 +199,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
 
@@ -219,7 +226,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
 
@@ -244,7 +252,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
 
@@ -270,7 +279,8 @@ integration('ProxyBuilder', () => {
       jobId,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      packageManager
     )
     await proxy.container.start()
 

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -64,7 +64,8 @@ async function buildProxyWithStopError(
     1,
     'job-token',
     'https://dependabot-api.example.com',
-    credentials
+    credentials,
+    'npm_and_yarn'
   )
 
   return {
@@ -193,6 +194,18 @@ describe('Proxy environment', () => {
     expect(createContainer).toHaveBeenCalledWith(
       expect.objectContaining({
         Env: expect.arrayContaining(['PROXY_CACHE=true'])
+      })
+    )
+  })
+
+  it('sets the PACKAGE_MANAGER env variable on the proxy container', async () => {
+    const {createContainer} = await buildProxyWithStopError(
+      alreadyStoppedError()
+    )
+
+    expect(createContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Env: expect.arrayContaining(['PACKAGE_MANAGER=npm_and_yarn'])
       })
     )
   })

--- a/__tests__/updater-builder-integration.test.ts
+++ b/__tests__/updater-builder-integration.test.ts
@@ -43,7 +43,8 @@ integration('UpdaterBuilder', () => {
       1,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      details['package-manager']
     )
     await proxy.container.start()
     const input = {job: details}
@@ -83,7 +84,8 @@ integration('UpdaterBuilder', () => {
       1,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      details['package-manager']
     )
     await proxy.container.start()
     const input = {job: details}
@@ -120,7 +122,8 @@ integration('UpdaterBuilder', () => {
       1,
       jobToken,
       dependabotApiUrl,
-      credentials
+      credentials,
+      details['package-manager']
     )
     await proxy.container.start()
     const input = {job: details}

--- a/__tests__/updater.test.ts
+++ b/__tests__/updater.test.ts
@@ -173,7 +173,8 @@ describe('Updater', () => {
         mockApiClient.params.jobId,
         'job-token',
         mockApiClient.params.dependabotApiUrl,
-        credentials
+        credentials,
+        mockJobDetails['package-manager']
       )
     })
   })

--- a/dist/main.js
+++ b/dist/main.js
@@ -100146,7 +100146,7 @@ var ProxyBuilder = class {
   docker;
   proxyImage;
   experiments;
-  async run(jobId2, jobToken, dependabotApiUrl, credentials) {
+  async run(jobId2, jobToken, dependabotApiUrl, credentials, packageManager) {
     const name = `dependabot-job-${jobId2}-proxy`;
     const config = this.buildProxyConfig(credentials);
     const cert = config.ca.cert;
@@ -100161,7 +100161,8 @@ var ProxyBuilder = class {
       name,
       externalNetwork,
       internalNetwork,
-      internalNetworkName
+      internalNetworkName,
+      packageManager
     );
     await ContainerService.storeInput(
       CONFIG_FILE_NAME,
@@ -100325,7 +100326,7 @@ var ProxyBuilder = class {
     const key = import_node_forge.pki.privateKeyToPem(keys.privateKey);
     return { cert: pem, key };
   }
-  async createContainer(jobId2, jobToken, dependabotApiUrl, containerName, externalNetwork, internalNetwork, internalNetworkName) {
+  async createContainer(jobId2, jobToken, dependabotApiUrl, containerName, externalNetwork, internalNetwork, internalNetworkName, packageManager) {
     const container = await this.docker.createContainer({
       Image: this.proxyImage,
       name: containerName,
@@ -100337,6 +100338,7 @@ var ProxyBuilder = class {
         `no_proxy=${process.env.no_proxy || process.env.NO_PROXY || ""}`,
         `JOB_ID=${jobId2}`,
         `JOB_TOKEN=${jobToken}`,
+        `PACKAGE_MANAGER=${packageManager}`,
         "PROXY_CACHE=true",
         `DEPENDABOT_API_URL=${dependabotApiUrl}`,
         `ACTIONS_ID_TOKEN_REQUEST_TOKEN=${process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN || ""}`,
@@ -100488,7 +100490,8 @@ var Updater = class {
       this.apiClient.params.jobId,
       this.apiClient.getJobToken(),
       this.apiClient.params.dependabotApiUrl,
-      this.credentials
+      this.credentials,
+      this.details["package-manager"]
     );
     await proxy.container.start();
     try {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -62,7 +62,8 @@ export class ProxyBuilder {
     jobId: number,
     jobToken: string,
     dependabotApiUrl: string,
-    credentials: Credential[]
+    credentials: Credential[],
+    packageManager: string
   ): Promise<Proxy> {
     const name = `dependabot-job-${jobId}-proxy`
     const config = this.buildProxyConfig(credentials)
@@ -81,7 +82,8 @@ export class ProxyBuilder {
       name,
       externalNetwork,
       internalNetwork,
-      internalNetworkName
+      internalNetworkName,
+      packageManager
     )
 
     await ContainerService.storeInput(
@@ -281,7 +283,8 @@ export class ProxyBuilder {
     containerName: string,
     externalNetwork: Network,
     internalNetwork: Network,
-    internalNetworkName: string
+    internalNetworkName: string,
+    packageManager: string
   ): Promise<Container> {
     const container = await this.docker.createContainer({
       Image: this.proxyImage,
@@ -296,6 +299,7 @@ export class ProxyBuilder {
         `no_proxy=${process.env.no_proxy || process.env.NO_PROXY || ''}`,
         `JOB_ID=${jobId}`,
         `JOB_TOKEN=${jobToken}`,
+        `PACKAGE_MANAGER=${packageManager}`,
         'PROXY_CACHE=true',
         `DEPENDABOT_API_URL=${dependabotApiUrl}`,
         `ACTIONS_ID_TOKEN_REQUEST_TOKEN=${process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN || ''}`,

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -36,7 +36,8 @@ export class Updater {
       this.apiClient.params.jobId,
       this.apiClient.getJobToken(),
       this.apiClient.params.dependabotApiUrl,
-      this.credentials
+      this.credentials,
+      this.details['package-manager']
     )
     await proxy.container.start()
 


### PR DESCRIPTION
### What & why

The Dependabot proxy runs in its own container and receives a curated set of env vars plus a credentials/experiments-only `config.json` — it never gets the full `job.json`. As a result `os.Getenv("PACKAGE_MANAGER")` was always empty in the proxy.

This is a prerequisite for the egress allowlist work: the allowlist keys its per-ecosystem defaults off `PACKAGE_MANAGER`, and the observability metric tags on it. Without this value, the allowlist degrades to GitHub-infra-only (every registry/CDN request would `403` under enforce), and `package_manager` shows empty in Datadog.

> **Note:** dependabot-core was **not** affected — it already receives the full job (including `package-manager`) via `job.json`. This gap was specific to the proxy container.

### Changes

- `src/updater.ts` — forward `details['package-manager']` into `proxyBuilder.run(...)`.
- `src/proxy.ts` — `run()` / `createContainer()` accept a `packageManager` param; add `PACKAGE_MANAGER=${packageManager}` to the proxy container `Env`.
- `dist/main.js` — rebuilt (`npm run package`).
- Tests updated + new assertion that `PACKAGE_MANAGER` is set on the container.

### Testing

- `npm run typecheck`, `lint-check`, `format-check`, `package` — all pass.
- Unit tests (proxy/updater/main) — 102 passing, incl. new `PACKAGE_MANAGER` env test.
- Integration tests not run (require Docker).

### Related

- Proxy PR: dependabot/proxy#230